### PR TITLE
fix(logger-impl): fix ODR violations caused by template specializations

### DIFF
--- a/src/ConsoleLoggerImpl.hpp
+++ b/src/ConsoleLoggerImpl.hpp
@@ -63,19 +63,19 @@ namespace {
 constexpr auto get_text_style(LogLevel loglevel) -> fmt::text_style {
     switch (loglevel) {
     case LogLevel::Debug:
-        return fmt::text_style();
+        return {};
     case LogLevel::Warn:
         return fmt::fg(fmt::color::yellow);
     case LogLevel::Error:
         return fmt::fg(fmt::color::red);
     }
 
-    return fmt::text_style();
+    return {};
 }
 } // namespace
 
 template <>
-void ConsoleLoggerImpl<LogStrategy::Blocking>::log(LogLevel loglevel,
+inline void ConsoleLoggerImpl<LogStrategy::Blocking>::log(LogLevel loglevel,
                                                    const std::string& logmsg) {
     const auto time_now = std::chrono::system_clock::now();
 
@@ -86,7 +86,7 @@ void ConsoleLoggerImpl<LogStrategy::Blocking>::log(LogLevel loglevel,
 }
 
 template <>
-void ConsoleLoggerImpl<LogStrategy::Immediate>::log(LogLevel loglevel,
+inline void ConsoleLoggerImpl<LogStrategy::Immediate>::log(LogLevel loglevel,
                                                     const std::string& logmsg) {
     const auto time_now = std::chrono::system_clock::now();
 

--- a/src/FileLoggerImpl.hpp
+++ b/src/FileLoggerImpl.hpp
@@ -76,7 +76,7 @@ auto get_logmsg_label(LogLevel loglevel) -> std::string_view {
 } // namespace
 
 template <>
-void FileLoggerImpl<LogStrategy::Blocking>::log(LogLevel loglevel,
+inline void FileLoggerImpl<LogStrategy::Blocking>::log(LogLevel loglevel,
                                                 const std::string& logmsg) {
     const auto time_now = std::chrono::system_clock::now();
 
@@ -87,7 +87,7 @@ void FileLoggerImpl<LogStrategy::Blocking>::log(LogLevel loglevel,
 }
 
 template <>
-void FileLoggerImpl<LogStrategy::Immediate>::log(LogLevel loglevel,
+inline void FileLoggerImpl<LogStrategy::Immediate>::log(LogLevel loglevel,
                                                  const std::string& logmsg) {
     const auto time_now = std::chrono::system_clock::now();
 


### PR DESCRIPTION
Inline template functions to prevent possibility of ODR violation errors in the future. 